### PR TITLE
add transaparent background to console body

### DIFF
--- a/console/console.css
+++ b/console/console.css
@@ -4,6 +4,7 @@ body {
     width: 100%;
     position: absolute;
     bottom: 0px;
+    background-color: transparent !important;
 }
 
 body * {


### PR DESCRIPTION
If you have specified default body background color (i.e. using gnome dark-theme), it renders console over the page content. This should fix it.